### PR TITLE
Bluetooth reconnect crashes

### DIFF
--- a/esp32_iGrill.ino
+++ b/esp32_iGrill.ino
@@ -668,7 +668,7 @@ void heartBeatPrint()
   }
   else //If we dont have an mqtt client set we need to initate a new BLE Scan to try and find a device.
   {
-    if(num%6 == 0) //Only attempt to re-scan every 6th time we make it to the check unconnected (If using default this will be once a min.)
+    if(num%3 == 0) //Only attempt to re-scan every 3th time we make it to the check unconnected (If using default this will be twice a min.)
       reScan = true; //Set the BLE rescan flag to true to initiate a new scan
   }
   num++;
@@ -1266,7 +1266,7 @@ void check_status()
 
   // Print iGrill System Info every IGRILL_HEARTBEAT_INTERVAL (5) minutes.
   if ((current_millis > igrillheartbeat_timeout) || (igrillheartbeat_timeout == 0))
-  { 
+  {
     publishSystemInfo();
     igrillheartbeat_timeout = current_millis + IGRILL_HEARTBEAT_INTERVAL;
   }
@@ -1358,8 +1358,8 @@ void setup()
   BLEDevice::setPower(ESP_PWR_LVL_P7);
   BLEScan* pBLEScan = BLEDevice::getScan();
   pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
-  pBLEScan->setInterval(1349);
-  pBLEScan->setWindow(449);
+  pBLEScan->setInterval(100);
+  pBLEScan->setWindow(99);
   pBLEScan->setActiveScan(true);
   pBLEScan->start(5, false);
   connectMQTT();
@@ -1394,7 +1394,7 @@ void loop()
   else if(reScan)
   {
     IGRILLLOGGER("Scanning for iGrill Devices...", 0);
-    BLEDevice::getScan()->start(5, false);
+    BLEDevice::getScan()->start(2, false);
     reScan = false; //Set reScan to false now that a scan has been started if a device is not found at next heartbeat a new scan will be started
   }
   check_status();


### PR DESCRIPTION
Hi,

I experienced some problems regarding bluetooth connection. Sometimes the esp took a very long time to connect to my iGrillv3. So I did some research and found that it scans very temperate and did not used all available resources. So I switched some parameters to values found in the BLE examples of the used library. Now it seems to me that the esp connects much faster and reliable to the iGrill.

Second I found some crashes of the device. It seems that they occur randomly but I found these are two kind of crashes. One occured always after the loss of bluetooth connection. It can be reproduced by switching the iGrill off and on. At the moment the connection was etablisched the second time, the esp crashes. The reason was incorrect memory management. Memory allocated by `new` should always be released by `delete` (not by `free`). Using `free` results in a missing destructor call. At this point I also fixed some memory leaks. There is still at least one more memory leak I did't find yet. But it eats only memory if the bluetooth connection gets lost and reconnects. After a few hundred such cases the esp crash on out of memory situation and reboots -> not very dramatic.

The other crash occure _sometimes_. The esp says:
```
Guru Meditation Error: Core  0 panic'ed (Interrupt wdt timeout on CPU0)
```
I suppose it is an issue on the wifi. But I'm not sure and don't have a solution yet.